### PR TITLE
Fix mobile navigation overlap with dark mode toggle

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -558,6 +558,7 @@ body {
     .nav-toggle-label {
         display: flex;
         order: 1;
+        margin-right: 60px; /* Space for theme toggle */
     }
     
     .theme-toggle {


### PR DESCRIPTION
## Summary
Fixes mobile navigation issue where the hamburger menu overlapped with the dark mode toggle, making both buttons inaccessible.

## Problem
- Dark mode toggle positioned at `top: 16px; right: 16px;` with fixed positioning
- Hamburger menu displayed in same area on mobile screens  
- Users unable to access navigation or theme toggle

## Solution
- Added `margin-right: 60px` to `.nav-toggle-label` on mobile screens
- Pushes hamburger menu left to avoid overlap with theme toggle
- Both buttons now accessible and functional

## Testing
- [x] Tested on mobile viewport (< 768px width)
- [x] Verified both navigation toggle and theme toggle work
- [x] Confirmed no visual overlap between buttons
- [x] Desktop layout remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)