### PR TITLE
Update insulin calculator default values

### DIFF
--- a/assets/js/calculator.js
+++ b/assets/js/calculator.js
@@ -6,8 +6,8 @@ class InsulinCalculator {
     this.state = {
       currentBG: '',
       carbs: '',
-      icr: 30, // Updated from 20 to 15 (more common adult baseline)
-      isf: 80, // Updated from 80 to 50 mg/dL (standard adult baseline)
+      icr: 40, // Insulin-to-Carb Ratio: 1 unit per 40g of carbs
+      isf: 70, // Insulin Sensitivity Factor: 1 unit drops BG by 70 mg/dL
       targetBG: 120,
       insulinType: 'Humalog (Lispro)',
       showSources: false,


### PR DESCRIPTION
- Change ICR from 1:30 to 1:40 (1 unit per 40g carbs)
- Change ISF from 1:80 to 1:70 mg/dL (1 unit drops BG by 70 mg/dL)
- Target BG remains 120 mg/dL

🤖 Generated with [Claude Code](https://claude.com/claude-code)