### PR TITLE
Add /crosspost pipeline: liftout cards + Playwright drafts + X/IG API scripts

### DIFF
--- a/.claude/skills/crosspost/SKILL.md
+++ b/.claude/skills/crosspost/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: crosspost
+description: >-
+  Cross-publish a live humaine.studio post to Substack, Medium, X, and
+  Instagram — share cards via liftout, platform copy in Chris's voice,
+  draft-gated publishing (Playwright drafts for Substack/Medium, API posts for
+  X/IG only after Chris approves the copy). Trigger: "/crosspost <post-url>",
+  "crosspost this", "mirror to substack/medium", "share this post".
+---
+
+# Crosspost pipeline
+
+Input: a LIVE humaine.studio post URL. Never run against a draft — every
+platform copy links back to the canonical URL, which must already resolve.
+
+**Draft-gated, always.** Nothing publishes without Chris approving the copy
+and the drafts. Playwright creates drafts; Chris clicks Publish. API posts
+(X, IG) run only after he approves the exact text.
+
+## 1. Share cards (liftout)
+
+```
+/liftout:create <post-url> portrait    # Instagram 4:5
+/liftout:create <post-url> landscape   # X / OG
+```
+
+Copy the cards into the site so Instagram has a public image URL:
+`assets/images/social/<slug>-portrait.png` and `<slug>-landscape.png`.
+Commit + PR + merge (cards must be live at humaine.studio before the IG step).
+
+## 2. Platform copy
+
+Draft all four, then show Chris for approval before ANY posting. Voice rules:
+plain and direct, parentheses over em dashes, no coined epigrams, no
+hashtag-stuffing (see memory: feedback_parens-over-em-dashes,
+feedback_no-aphoristic-claude-speak).
+
+- **Substack intro**: 2-3 sentence email hook above the mirrored body.
+- **X**: single post, hook + link (a URL-bearing post costs ~$0.22 in API
+  credits — one post, not a thread, unless Chris asks).
+- **Instagram caption**: 2-4 sentences + "link in bio" phrasing (IG captions
+  can't link); note the post URL for Chris's bio link.
+- **Medium**: no copy needed (import preserves the article).
+
+## 3. Substack — Playwright draft
+
+1. `mcp__plugin_playwright_playwright__browser_navigate` to
+   https://substack.com/home — verify logged in as humainestudio.
+2. New post → paste title, intro hook, then the article body (from the live
+   page, not the markdown — rendered HTML pastes cleaner).
+3. Settings → **set canonical URL to the humaine.studio post**. This is the
+   step that must never be skipped; SEO credit depends on it.
+4. Save draft. STOP. Tell Chris the draft is ready — he publishes.
+
+## 4. Medium — Playwright import (sets canonical automatically)
+
+1. Navigate to https://medium.com/p/import
+2. Paste the post URL, run the import. Medium's importer sets
+   `rel=canonical` to the source itself — verify in the imported draft's
+   settings that the canonical shows humaine.studio.
+3. Fix any mangled figures (check all three images imported).
+4. Add up to 5 tags. Save draft. STOP — Chris publishes.
+
+## 5. X — API post (after copy approval)
+
+```
+uv run scripts/crosspost/x-post.py "approved post text with URL"
+```
+
+One-time setup (documented in the script header): X developer account with
+pay-per-use credits; four OAuth 1.0a secrets stored in 1Password item
+"X API" in Developer Vault. Never paste keys into the terminal.
+
+## 6. Instagram — Graph API (after copy approval + cards merged)
+
+```
+uv run scripts/crosspost/ig-post.py <card-public-url> "approved caption"
+```
+
+One-time setup (script header): IG business/creator account linked to a
+Facebook page, Meta app with instagram_content_publish, long-lived token in
+1Password item "Meta Graph API". If the token or linkage is missing, output
+the card path + caption for a 30-second manual post instead of failing.
+
+## 7. Wrap up
+
+- Confirm each platform's final state to Chris in one table (drafted /
+  posted / manual-fallback).
+- Substack/Medium: remind him both are drafts awaiting his Publish click.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,15 +700,10 @@ claude-code "ultrathink: plan a comprehensive content strategy for showcasing co
 3. **Implement**: "Now implement the plan, following our style guidelines"
 4. **Test**: "Test the changes locally and fix any issues"
 5. **Commit**: "Create a descriptive commit and push to feature branch"
-6. **Wrap-up**: "Run `specstory sync` to document the session"
 
 ### Session End Workflow
-**ALWAYS run at the end of every session:**
-```bash
-# Sync session history to Specstory (local only, no cloud sync)
-specstory sync --no-cloud-sync
-```
-This documents your work and maintains a searchable history of all Claude Code sessions in `.specstory/` directory.
+Specstory was retired (the CLI is uninstalled); no session-sync step is
+required. Historical session logs remain in `.specstory/history/` (gitignored).
 
 ## Emergency Procedures
 
@@ -812,9 +807,8 @@ From `docs/calculator-roadmap.md`:
 9. **Follow PR workflow** - all changes go through pull request review
 10. **NEVER mix HTML containers with markdown** - use pure markdown or pure HTML
 11. **ALWAYS include `.nojekyll`** in experiment directories - prevents Jekyll processing of React/Vite apps
-12. **ALWAYS run `specstory sync --no-cloud-sync` at session end** - documents work history automatically
-13. **Check active issues** - some CI checks are non-blocking (spell check, Lighthouse)
-14. **Privacy disclosure** - any new tracking must be documented in privacy.md
+12. **Check active issues** - some CI checks are non-blocking (spell check, Lighthouse)
+13. **Privacy disclosure** - any new tracking must be documented in privacy.md
 
 ## Quick Reference
 
@@ -826,7 +820,6 @@ bundle exec jekyll serve           # Start local server
 git diff                           # Review changes
 gh pr create                       # Create pull request
 bundle exec jekyll build           # Test build process
-specstory sync --no-cloud-sync     # Document session history (run at session end)
 ```
 
 ### File Locations

--- a/scripts/crosspost/ig-post.py
+++ b/scripts/crosspost/ig-post.py
@@ -1,0 +1,70 @@
+# /// script
+# dependencies = ["requests"]
+# ///
+"""Publish a share card to Instagram via the Meta Graph API.
+
+One-time setup:
+  1. Convert the Instagram account to business/creator and link it to a
+     Facebook page.
+  2. developers.facebook.com -> create app -> add Instagram Graph API ->
+     generate a long-lived access token with instagram_basic +
+     instagram_content_publish.
+  3. Store in 1Password, Developer Vault, item "Meta Graph API":
+     fields: access_token, ig_user_id
+
+The image must be a PUBLIC https URL (merge the liftout card into the site
+first; use its humaine.studio URL).
+
+Usage:
+  uv run scripts/crosspost/ig-post.py <image-url> "approved caption"
+"""
+import subprocess
+import sys
+import time
+
+import requests
+
+GRAPH = "https://graph.facebook.com/v21.0"
+
+
+def op(field: str) -> str:
+    return subprocess.run(
+        ["op", "read", f"op://Developer Vault/Meta Graph API/{field}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit('usage: uv run scripts/crosspost/ig-post.py <image-url> "caption"')
+    image_url, caption = sys.argv[1], sys.argv[2]
+    token, ig_user = op("access_token"), op("ig_user_id")
+
+    r = requests.post(f"{GRAPH}/{ig_user}/media", data={
+        "image_url": image_url, "caption": caption, "access_token": token,
+    })
+    if r.status_code != 200:
+        raise SystemExit(f"container error {r.status_code}: {r.text}")
+    container = r.json()["id"]
+
+    # Media containers process async; poll briefly before publishing.
+    for _ in range(10):
+        s = requests.get(f"{GRAPH}/{container}", params={
+            "fields": "status_code", "access_token": token,
+        }).json().get("status_code")
+        if s == "FINISHED":
+            break
+        if s == "ERROR":
+            raise SystemExit("Instagram rejected the media container")
+        time.sleep(3)
+
+    r = requests.post(f"{GRAPH}/{ig_user}/media_publish", data={
+        "creation_id": container, "access_token": token,
+    })
+    if r.status_code != 200:
+        raise SystemExit(f"publish error {r.status_code}: {r.text}")
+    print(f"published: media id {r.json()['id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/crosspost/x-post.py
+++ b/scripts/crosspost/x-post.py
@@ -1,0 +1,49 @@
+# /// script
+# dependencies = ["requests-oauthlib"]
+# ///
+"""Post a single approved tweet via the X API v2 (pay-per-use credits).
+
+One-time setup:
+  1. developer.x.com -> create app, enable OAuth 1.0a with Read & Write,
+     buy pay-per-use credits (~$0.015/post, ~$0.22 if it contains a URL).
+  2. Store the four secrets in 1Password, Developer Vault, item "X API":
+     fields: consumer_key, consumer_secret, access_token, access_token_secret
+
+Usage:
+  uv run scripts/crosspost/x-post.py "post text with https://link"
+
+Never pass keys on the command line; they load from 1Password at runtime.
+"""
+import subprocess
+import sys
+
+from requests_oauthlib import OAuth1Session
+
+
+def op(field: str) -> str:
+    return subprocess.run(
+        ["op", "read", f"op://Developer Vault/X API/{field}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or not sys.argv[1].strip():
+        raise SystemExit('usage: uv run scripts/crosspost/x-post.py "post text"')
+    text = sys.argv[1]
+    if len(text) > 280:
+        raise SystemExit(f"post is {len(text)} chars (max 280) — trim it")
+
+    session = OAuth1Session(
+        op("consumer_key"), op("consumer_secret"),
+        op("access_token"), op("access_token_secret"),
+    )
+    r = session.post("https://api.x.com/2/tweets", json={"text": text})
+    if r.status_code != 201:
+        raise SystemExit(f"X API error {r.status_code}: {r.text}")
+    tweet_id = r.json()["data"]["id"]
+    print(f"posted: https://x.com/i/status/{tweet_id}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Programmatic cross-publishing for new posts, draft-gated at every step.

## What
- **`.claude/skills/crosspost/`** — project skill driving the whole flow: liftout share cards (portrait for IG, landscape for X/OG) committed to the site for public URLs; platform copy drafted in house voice; Substack draft via Playwright with canonical URL set; Medium via its import flow (sets canonical itself); X and IG posted via API only after copy approval.
- **`scripts/crosspost/x-post.py`** — X API v2 single-post, pay-per-use credits, OAuth 1.0a secrets read from 1Password at runtime (never on the CLI), 280-char guard.
- **`scripts/crosspost/ig-post.py`** — Meta Graph API container → poll → publish, secrets from 1Password, public card URL required.
- **CLAUDE.md** — specstory session-sync ritual removed (CLI is uninstalled); reminder list renumbered.

## One-time setup still on Chris
- X: developer account + pay-per-use credits, four secrets into 1Password item "X API" (documented in script header)
- IG: business-account + FB page linkage, long-lived token into "Meta Graph API" item (documented in script header)
- Until then, the skill falls back to prepared copy + cards for manual posting.

## Insights
- Medium's import flow beats its deprecated API: it sets rel=canonical automatically, which is the one step that must never be missed.
- Both API scripts use uv inline-script dependencies (PEP 723) — no project dependency footprint for one-off publish tools.

## Verification
- Both scripts py_compile clean; op:// paths follow the 1Password convention; no secrets in the repo
- Skill follows the extend-don't-twin rule: supersedes the manual crosspost mode in the /article command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New scripts can publish to X/Instagram when run with approved copy; credentials stay out of the repo but runtime `op` access is required. Mostly docs/skill and optional tooling, not site runtime.
> 
> **Overview**
> Adds a **`/crosspost` Claude skill** that documents an end-to-end, **draft-gated** flow for mirroring live humaine.studio posts to Substack, Medium, X, and Instagram: liftout share cards committed to the site, platform copy for approval, Playwright drafts for Substack (canonical URL required) and Medium import, then API posting for X/IG only after approval.
> 
> Introduces **`scripts/crosspost/x-post.py`** (X API v2, OAuth 1.0a, 280-char check, secrets via `op` from 1Password) and **`scripts/crosspost/ig-post.py`** (Meta Graph API container → poll → publish, public image URL required).
> 
> **`CLAUDE.md`** drops the retired Specstory session-sync step from the workflow, quick reference, and reminders (list renumbered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451956a6d59270dcd736a1fb237a67c1d7885fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->