### PR TITLE
Fix: post images overflow content column; markdown tables unstyled

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -292,6 +292,39 @@ body {
     color: var(--text-color);
 }
 
+.post-content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 1.5em auto;
+    background: #fff;
+    border-radius: 4px;
+}
+
+[data-theme="dark"] .post-content img {
+    border: 1px solid var(--border-color);
+    padding: 8px;
+    box-sizing: border-box;
+}
+
+.post-content table {
+    border-collapse: collapse;
+    margin: 1.5em 0;
+    font-size: 15px;
+}
+
+.post-content th,
+.post-content td {
+    padding: 8px 14px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.post-content th {
+    color: var(--text-light);
+    font-weight: 600;
+}
+
 .post-content h1,
 .post-content h2,
 .post-content h3,


### PR DESCRIPTION
Two site-wide CSS gaps surfaced by the config-trim post:

1. **No `max-width` on `.post-content img`** — figures shipped at 2x retina (1400px) display at natural size inside the 700px column, overflowing the layout. Fix constrains to 100%, centers, gives chart PNGs a white background, and adds a subtle border+padding in dark mode so white-background figures don't glare.
2. **No table styling** — markdown tables rendered with zero padding or borders (the Results table read as crammed text). Adds minimal borders/padding consistent with the site's hairline style.

Verified with local build; benefits all past posts with images/tables, not just the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in `.post-content`; no logic, auth, or data changes.
> 
> **Overview**
> Adds **post-body presentation rules** in `main.css` so wide figures and markdown tables behave inside the ~700px column.
> 
> **Images** under `.post-content` are capped at `max-width: 100%`, centered, given a white background for chart PNGs, and in dark mode a hairline border plus padding so white figures don’t glare.
> 
> **Tables** get collapsed borders, cell padding, and bottom borders on rows using `var(--border-color)`, with header cells styled slightly heavier—matching the site’s existing hairline look.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f1b1a66e0a9a66e54e411dee33076423044aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->