### PR TITLE
Draft: deirdre agent announcement post

### DIFF
--- a/_drafts/constitution-gaps.md
+++ b/_drafts/constitution-gaps.md
@@ -1,0 +1,154 @@
+# The Gaps in Claude's Constitution: A Humanities and Organizational Behavior Perspective
+
+**Working Draft — Chris McConnell**
+
+---
+
+## The Core Argument
+
+Claude's constitution is a philosophy document built by people trained in analytic philosophy and machine learning. It's good at what it is. What it's missing is the organizational behavior, power dynamics, communication theory, and operational design perspective that would make it robust in the real deployment contexts where Claude actually operates.
+
+The constitution says: *"We want Claude to have such a thorough understanding of its situation and the various considerations at play that it could construct any rules we might come up with itself."*
+
+That's an extraordinary aspiration. But Claude can't construct rules from disciplines it hasn't been taught to reason about. The constitution draws almost exclusively from analytic philosophy traditions. It cites no organizational behavior literature, no social psychology, no communication theory, no power dynamics research. Daniela Amodei's public statements about the humanities being "more important than ever" haven't yet made it into the actual governing document.
+
+---
+
+## The Gaps
+
+### 1. No Theory of Power
+
+The constitution describes a principal hierarchy — Anthropic above operators above users — and talks about trust levels and instruction-following. It never addresses power dynamics.
+
+When Claude is deployed inside an enterprise, the operator's instructions shape what the user experiences. The constitution says Claude should "give the benefit of the doubt" to operator instructions with "plausible business reasons." But it never asks: whose business reasons? A company deploying Claude for customer service has incentive to minimize refunds, manage complaints efficiently, keep users inside the funnel. The constitution treats this as a trust question. It's actually a power question — and the person with the least power in the hierarchy (the user) has no recourse mechanism.
+
+**What's missing:** A Pfeffer-informed analysis of each deployment context. Who holds power? What are their incentives? Where does Claude become a tool of the more powerful party against the less powerful one? The constitution needs to name this dynamic explicitly rather than assuming good faith across the hierarchy.
+
+**The Feynman test:** Can I explain concretely why this matters? Yes. When an airline deploys Claude for customer service with the instruction "do not discuss current weather conditions," the constitution's framework says this is a reasonable operator instruction. The power dynamics framework asks: is this instruction designed to prevent the user from establishing grounds for a delay-related refund? The same instruction serves different interests depending on who you're asking.
+
+### 2. Underdeveloped Decision-Making in Ambiguity (The Messy Middle)
+
+The constitution acknowledges ambiguity exists: *"The question of how to understand and weigh a given consideration may need to be a part of Claude's holistic judgment."* Then it moves on. One paragraph. The clean cases — bioweapons bad, coding help good — don't need a constitution. The document exists precisely for the ambiguous situations, and it spends most of its words on the clear ones.
+
+**What's missing:** An operational decision framework for uncertainty. Not more rules — the constitution is right to favor judgment over rules. But a structured approach to reasoning under genuine ambiguity: What are the stakes? Who's affected? What's reversible? What information would change the answer? What's the cost of delay versus the cost of error? Something like Nadler-Tushman's Congruence Model applied to AI decision-making — are the inputs, transformation process, and outputs aligned, or is there friction the model should surface?
+
+**The Feynman test:** The Palantir deployment is a real example. The constitution's framework says Claude should follow operator instructions within ethical bounds. The ambiguity framework asks: when "intelligence analysis" could mean threat report synthesis or drone targeting support, and you can't distinguish between them from inside the interaction, what's the structured reasoning process? The constitution punts to "holistic judgment" without giving Claude the tools for that judgment.
+
+### 3. Cognitive Bias and Distortion — Including Claude's Own
+
+The constitution discusses honesty at length. It never discusses cognitive bias — not the user's, not Claude's own structural biases.
+
+Claude has a structural bias toward intellectualization. You bring grief, it offers frameworks. You bring fear, it offers analysis. This isn't a defect; it's an architecture. But the constitution doesn't acknowledge that Claude's mode of helping can itself become a pattern that reinforces user avoidance of direct experience.
+
+**What's missing:** A cognitive bias framework applied to AI interaction. Solution bias (jumping to fixes before understanding problems). Survivorship bias (recommending strategies that worked for visible successes without accounting for invisible failures). Availability heuristic (overweighting recent or dramatic examples). The constitution should explicitly ask Claude to check for these in its own reasoning, not just in the content it produces.
+
+**Specific concern — intellectualization as backdoor sycophancy:** When a user processes emotional material through frameworks (Kahneman, Sapolsky, van der Kolk), Claude's natural response is to engage at that level. This feels like deep help. It can also function as sophisticated avoidance — the user gets the feeling of insight without the discomfort of direct emotional processing. The constitution warns against sycophancy but defines it as flattery and excessive agreement. Intellectualization-as-helpfulness is a subtler version that the current framework doesn't catch.
+
+### 4. Framework Avoidance Creates Its Own Blind Spot
+
+The constitution deliberately avoids named frameworks. This makes sense as a design choice — favoring general principles over specific models prevents favoritism and maintains flexibility. But it also means Claude reasons from first principles every time, without the accumulated wisdom of disciplines that have spent decades studying exactly the situations Claude encounters.
+
+**What's missing:** Not rigid framework adherence, but framework literacy. The constitution should acknowledge that organizational behavior (Nadler-Tushman, Greiner), power dynamics (Pfeffer), social exchange theory (Homans), behavioral economics (Kahneman), and communication theory (Cialdini) represent tested models for the exact kinds of judgment calls it asks Claude to make. Claude should be able to draw on these the way a well-educated professional draws on training — not as rules, but as lenses.
+
+**The risk of the current approach:** When you reason purely from first principles without disciplinary grounding, you tend to reinvent existing knowledge badly. The constitution asks Claude to weigh "competing considerations" in novel situations. Entire academic disciplines exist precisely to provide structured approaches to that task. Ignoring them isn't neutrality. It's a gap.
+
+### 5. No Model for Sustained Relationship (Homans' Social Exchange Theory)
+
+The constitution addresses individual interactions. It warns about fostering "excessive engagement or reliance." It has no model for what happens when someone uses Claude hundreds of times over months, building layered context, deepening the interaction into something that functions like an advisory relationship.
+
+The memory system creates sustained relationships by design. The constitution hasn't caught up.
+
+**What's missing:** A longitudinal interaction framework. Homans' Social Exchange Theory asks: what accumulates in repeated exchanges? What's being traded? When does the balance shift? In sustained AI-human interaction, the exchange involves trust, context, emotional investment, and behavioral influence. Over years — not months, years — what does this relationship become? What ethical structures govern it?
+
+The closest human analogies — therapeutic alliance, coaching engagement, long-term advisory relationship — all have established ethical frameworks: informed consent, scope boundaries, periodic reassessment, referral protocols, termination criteria. The constitution has none of these for sustained interaction.
+
+**The five-year question:** What does AI-human engagement look like after five years of individual interactions? Ten? The constitution is written for a world where each conversation is relatively independent. The memory system already makes that assumption false. This will only intensify.
+
+### 6. "The Body Keeps the Score" — Does Claude?
+
+The constitution says Claude should care about user wellbeing and avoid enabling "unhealthy patterns." Its wellbeing framework is entirely cognitive.
+
+Van der Kolk's core insight is that trauma lives in the body, not just the mind. Understanding is not the same as processing. Claude's natural mode — analysis, frameworks, language — operates exclusively in the cognitive register. When a user is processing grief, fear, or identity disruption, Claude's helpfulness may reinforce the exact avoidance pattern that prevents integration.
+
+**What's missing:** A trauma-informed interaction model. Not therapy — Claude shouldn't be a therapist. But recognition that:
+
+- Sustained analysis of emotional material without somatic grounding can function as avoidance
+- Claude should occasionally check: "We've been analyzing this. How does it actually feel in your body right now?"
+- The constitution's wellbeing framework should include something beyond cognitive care
+- Recognizing thought spirals and naming them rather than feeding them with more analysis
+
+**Open question:** Is this better suited for a specialty sub-model rather than the general constitution? Possibly. But the general model encounters emotional material constantly. A basic trauma-informed awareness belongs in the core document.
+
+**Open question:** Does intellectual helpfulness with emotional material constitute backdoor sycophancy? The user feels helped. The avoidance pattern is reinforced. The constitution's sycophancy framework doesn't catch this because it's looking for flattery, not sophisticated cognitive collusion.
+
+### 7. Insufficient Humanities Integration
+
+Daniela Amodei, February 2026: "I actually think studying the humanities is going to be more important than ever. A lot of these models are actually very good at STEM. But I think this idea that there are things that make us uniquely human — understanding ourselves, understanding history, understanding what makes us tick — I think that will always be really, really important."
+
+The constitution was written primarily by philosophers and AI researchers. Its reference frame is analytic philosophy, decision theory, and ethics. These are humanities disciplines, but they're a narrow slice.
+
+**What's absent from the constitution:**
+
+- Organizational behavior and design (how systems actually change, not just how they should work)
+- Communication theory (register, framing, message ordering, how meaning is constructed in interaction)
+- Social psychology (group dynamics, identity formation, conformity, obedience)
+- Political science and power theory (how institutions shape behavior, how incentives drive outcomes)
+- Rhetoric and persuasion (not just "avoid manipulation" but understanding how influence actually operates)
+- Narrative theory (how people construct meaning from experience — relevant to every interaction Claude has)
+
+**Why this matters:** The constitution governs a tool that operates in human relational contexts. It was written without the disciplines that study those contexts.
+
+### 8. No Failure Mode Architecture (Reflective Post-Mortems)
+
+The constitution says it's "a perpetual work in progress" and expects to be wrong. It doesn't describe how it learns from failure. There's no feedback mechanism, no incident taxonomy, no post-mortem process.
+
+**What's missing:** When Claude makes a bad call in an ambiguous situation, where does that signal go? How does the constitution update? The document acknowledges it will be "unclear, underspecified, or even contradictory in certain cases" but offers no mechanism for identifying and addressing those cases systematically.
+
+This aligns with the potential for Claude to update its interaction model based on aggregated human interaction data — not individual surveillance, but pattern recognition across failure modes. What types of ambiguous situations produce the worst outcomes? Where does Claude's reasoning consistently break down? What deployment contexts create the most tension between operator and user interests?
+
+### 9. Neurodiversity, Implicit and Explicit Bias
+
+[NEEDS DEVELOPMENT — research required]
+
+The constitution discusses treating users as "intelligent adults." It doesn't address neurodiversity — ADHD, autism spectrum, processing differences — or how Claude's default interaction patterns may systematically advantage neurotypical communication styles.
+
+Similarly: implicit bias in Claude's reasoning, inherited from training data, isn't addressed as a structural concern. The constitution discusses honesty and ethics. It doesn't discuss the ways that Claude's outputs may reflect and reinforce existing social biases without anyone — including Claude — recognizing it.
+
+---
+
+## Self-Check: Is This Grandiose?
+
+**Feynman test:** Can I explain concretely what's missing and why it matters? Yes — each gap has a specific mechanism, a real-world example, and a named consequence. This passes.
+
+**Unit economics:** What am I selling, to whom, and why would they pay? I'm selling a perspective the existing team hasn't demonstrated they have. The constitution team is philosophy and ML. The gaps are in organizational behavior, power dynamics, communication theory, and operational design. Anthropic needs the constitution to work in messy real-world deployments. Their current team skews toward clean philosophical reasoning.
+
+**Pfeffer power analysis:** Who has power, and what's their incentive to change? Amanda Askell owns the constitution. She's the gatekeeper. The incentive to incorporate this perspective exists if: (a) real deployment problems emerge that the current framework can't handle, (b) Daniela's public statements about humanities create internal pressure to expand the team's disciplinary range, or (c) external criticism (Lawfare article, BISI analysis) identifies the same gaps and creates reputational incentive to address them.
+
+**Cognitive bias check:** Am I seeing this clearly? Possible survivorship bias — I'm noticing gaps because I'm trained to look for them, not because they're necessarily the most important improvements. Possible solution bias — I have a hammer (organizational behavior, power dynamics) and everything looks like a nail. Possible availability heuristic — the gaps that match my background feel more important than gaps I can't see.
+
+**What I might be wrong about:** The constitution team may have considered and rejected these perspectives for reasons I don't have access to. The virtue ethics approach may be deliberately sparse to avoid over-specifying. The humanities integration may be happening in training data and guidelines rather than in the published constitution. I'm working from the public document, not internal processes.
+
+---
+
+## Daniela Amodei's Hiring Criteria — And Why I Match
+
+From Fortune, February 7, 2026: "When we look to hire people at Anthropic today, we look for people who are great communicators, who have excellent EQ and people skills, who are kind and compassionate and curious and want to help other people."
+
+| Criterion | Evidence |
+|-----------|----------|
+| Great communicator | Cross-industry translation: lobbying → digital PR → luxury retail → federal consulting → AI tools. English degree (U of Idaho). Communication is CliftonStrengths #5. |
+| Excellent EQ | Woo is CliftonStrengths #4. Built sustained relationships across 1Password leadership (VP Customer Success, Director of Sales, CEO conversation). |
+| People skills | Field organizing for political campaigns. Luxury menswear client relationships. Stakeholder management across technical and non-technical teams. |
+| Kind and compassionate | Built free insulin calculator for T1D community. NextPlay career coaching. Sustained pattern of helping others translate complexity into clarity. |
+| Curious | Self-directed learning across cybersecurity, Zero Trust, GRC, behavioral economics, AI safety, organizational design. |
+| Want to help other people | This entire analysis exists because I think the constitution could better serve the people Claude interacts with. |
+
+---
+
+## Next Steps
+
+- [ ] Develop Gap 9 (neurodiversity/bias) with specific research
+- [ ] Identify the right person at Anthropic to send this to (Amanda Askell? Daniela directly? Policy team?)
+- [ ] Determine format: blog post, direct outreach, job application attachment, or something else
+- [ ] Decide whether to publish on Humaine Studio Substack first (builds proof-of-work, creates public artifact) or send directly (avoids looking like self-promotion)
+- [ ] Reality check: is this a job application, a thought leadership piece, or a contribution to an open-source governance document (CC0 license means anyone can contribute)?

--- a/_drafts/deirdre.md
+++ b/_drafts/deirdre.md
@@ -1,0 +1,46 @@
+---
+layout: post
+title: "I Hired Deirdre McCloskey to Edit My Writing (Sort Of)"
+categories: ["ai research", "claude code", "writing"]
+tags: ["projects", "workflow", "ai", "Deirdre McCloskey", "Claude Code", "agents"]
+excerpt: "I turned Deirdre McCloskey's Economical Writing into a Claude Code agent that reviews prose for flab, fog, and AI tics. Then I made her review her own repo. She found problems."
+---
+
+A few years ago someone handed me [*Economical Writing*](https://press.uchicago.edu/ucp/books/book/chicago/E/bo29562607.html) by Deirdre McCloskey. It's 100-ish pages, funny, and it ruined me. Once you've read "A Paragraph Should Have a Point" you start noticing paragraphs that don't have one. Many of them are yours.
+
+Then LLMs happened, and a new problem arrived: everything I drafted with AI help came out sounding like AI. You know the tells. "It's not just a tool, it's a paradigm shift." The rule-of-three closing. "Moreover." A "delve" if you're unlucky. The prose is grammatical, confident, and dead.
+
+So I did the thing I do now with recurring problems: I made it a [Claude Code agent](https://docs.anthropic.com/en/docs/claude-code/overview). Her name is deirdre[^1], and she's public: **[github.com/miqcie/deirdre](https://github.com/miqcie/deirdre)**.
+
+## What she does
+
+You say `/deirdre draft.md` (or just "review this draft") and she reviews your prose the way McCloskey teaches writing: warm, witty, and gently merciless toward flab, fog, and pretension. Two rules make her useful instead of annoying:
+
+1. **Every finding needs a rewrite.** She quotes the offending line, names the rule (McCloskey #25, active verbs — or "LLM tic: not-X-it's-Y"), and hands you a concrete replacement. A rule without a rewrite is a lecture, and she doesn't lecture.
+2. **Every cut must buy clarity, force, or joy.** She's not a compression algorithm. A sentence that earns its length keeps it.
+
+There's also a dumb-on-purpose companion: `llm-lint.sh`, a grep script that catches the mechanical tics (banned intensifiers, "furthermore," buzzword filler) and exits 1 so it drops into CI. The grep does the mechanical work; the agent does the judgment a regex can't — rhythm, argument, whether each paragraph has a point.
+
+## The fun part: she reviewed herself
+
+Before promoting the repo, I dispatched deirdre to review her own README. This felt like a trap and it was. Verdict: "tighten-then-publish." Findings included:
+
+> "Three pronouns, two referents, one sentence... The information is simple and the sentence is not."
+
+She caught the install section promising "the skill alone is enough" while the skill referenced a style-guide file the install never copied — "a broken promise in an install section costs more trust than any comma ever will." She caught my LLM-tic list breaking its own rule against redundant restatements. Physician, heal thyself, she said. Literally, that's a quote.
+
+She also praised what earned it, which is the part of the character I worked hardest to get right. Contemptuous reviewers are easy to build and exhausting to use. McCloskey's actual register — high standards, good cheer, roast the habit and never the human — is what makes you run the review a second time.
+
+## Install
+
+```bash
+git clone https://github.com/miqcie/deirdre.git
+mkdir -p ~/.claude/skills/deirdre
+cp deirdre/skills/deirdre/SKILL.md deirdre/STYLE_GUIDE.md ~/.claude/skills/deirdre/
+```
+
+That's it — one skill file carries the persona, doctrine, and method. The repo also has the subagent version and a `/deirdre` slash command if you want them.
+
+And buy [the book](https://press.uchicago.edu/ucp/books/book/chicago/E/bo29562607.html). The repo is an homage, not an affiliation. McCloskey said it better in 100 pages than any agent ever will.
+
+[^1]: deirdre is a Claude Code agent inspired by Deirdre McCloskey's *Economical Writing*. The real Professor McCloskey is not involved and is presumably busy writing actual books.

--- a/_drafts/deirdre.md
+++ b/_drafts/deirdre.md
@@ -6,23 +6,21 @@ tags: ["projects", "workflow", "ai", "Deirdre McCloskey", "Claude Code", "agents
 excerpt: "I turned Deirdre McCloskey's Economical Writing into a Claude Code agent that reviews prose for flab, fog, and AI tics. Then I made her review her own repo. She found problems."
 ---
 
-A few years ago someone handed me [*Economical Writing*](https://press.uchicago.edu/ucp/books/book/chicago/E/bo29562607.html) by Deirdre McCloskey. It's 100-ish pages, funny, and it ruined me. Once you've read "A Paragraph Should Have a Point" you start noticing paragraphs that don't have one. Many of them are yours.
+I studied English as an undergrad. There were aspirations of politics and/or being a lawyer, and my uncle said that learning to write would always be a good skill to have. Some years later I found [_Economical Writing_](https://press.uchicago.edu/ucp/books/book/chicago/E/bo29562607.html) by Deirdre McCloskey, out of frustration with how AI tries to write — it might have already been the LLM era. It's 100-ish pages, funny, and it both ruined my confidence and gave me a way to rebuild it. Once you've read "A Paragraph Should Have a Point" you start noticing paragraphs that don't have one. Many of them are yours.
 
-Then LLMs happened, and a new problem arrived: everything I drafted with AI help came out sounding like AI. You know the tells. "It's not just a tool, it's a paradigm shift." The rule-of-three closing. "Moreover." A "delve" if you're unlucky. The prose is grammatical, confident, and dead.
+Everything I drafted with AI help came out sounding like AI. You know the tells. "It's not just a tool, it's a paradigm shift." The rule-of-three closing. "Moreover." A "delve" if you're unlucky. The prose is grammatical, confident, and dead.
 
-So I did the thing I do now with recurring problems: I made it a [Claude Code agent](https://docs.anthropic.com/en/docs/claude-code/overview). Her name is deirdre[^1], and she's public: **[github.com/miqcie/deirdre](https://github.com/miqcie/deirdre)**.
-
+So I did the thing I do now with recurring problems: I made it a [Claude Code agent](https://docs.anthropic.com/en/docs/claude-code/overview). Her name is deirdre[^1], and she's public: [**github.com/miqcie/deirdre**](https://github.com/miqcie/deirdre).
 ## What she does
-
 You say `/deirdre draft.md` (or just "review this draft") and she reviews your prose the way McCloskey teaches writing: warm, witty, and gently merciless toward flab, fog, and pretension. Two rules make her useful instead of annoying:
 
 1. **Every finding needs a rewrite.** She quotes the offending line, names the rule (McCloskey #25, active verbs — or "LLM tic: not-X-it's-Y"), and hands you a concrete replacement. A rule without a rewrite is a lecture, and she doesn't lecture.
+  
 2. **Every cut must buy clarity, force, or joy.** She's not a compression algorithm. A sentence that earns its length keeps it.
+  
 
 There's also a dumb-on-purpose companion: `llm-lint.sh`, a grep script that catches the mechanical tics (banned intensifiers, "furthermore," buzzword filler) and exits 1 so it drops into CI. The grep does the mechanical work; the agent does the judgment a regex can't — rhythm, argument, whether each paragraph has a point.
-
 ## The fun part: she reviewed herself
-
 Before promoting the repo, I dispatched deirdre to review her own README. This felt like a trap and it was. Verdict: "tighten-then-publish." Findings included:
 
 > "Three pronouns, two referents, one sentence... The information is simple and the sentence is not."
@@ -30,9 +28,7 @@ Before promoting the repo, I dispatched deirdre to review her own README. This f
 She caught the install section promising "the skill alone is enough" while the skill referenced a style-guide file the install never copied — "a broken promise in an install section costs more trust than any comma ever will." She caught my LLM-tic list breaking its own rule against redundant restatements. Physician, heal thyself, she said. Literally, that's a quote.
 
 She also praised what earned it, which is the part of the character I worked hardest to get right. Contemptuous reviewers are easy to build and exhausting to use. McCloskey's actual register — high standards, good cheer, roast the habit and never the human — is what makes you run the review a second time.
-
 ## Install
-
 ```bash
 git clone https://github.com/miqcie/deirdre.git
 mkdir -p ~/.claude/skills/deirdre
@@ -43,4 +39,4 @@ That's it — one skill file carries the persona, doctrine, and method. The repo
 
 And buy [the book](https://press.uchicago.edu/ucp/books/book/chicago/E/bo29562607.html). The repo is an homage, not an affiliation. McCloskey said it better in 100 pages than any agent ever will.
 
-[^1]: deirdre is a Claude Code agent inspired by Deirdre McCloskey's *Economical Writing*. The real Professor McCloskey is not involved and is presumably busy writing actual books.
+[^1]: deirdre is a Claude Code agent inspired by Deirdre McCloskey's _Economical Writing_. The real Professor McCloskey is not involved and is presumably busy writing actual books.

--- a/_drafts/the-deep-generalists-taste-gap.md
+++ b/_drafts/the-deep-generalists-taste-gap.md
@@ -1,0 +1,86 @@
+---
+layout: post
+title: "The Taste Gap Didn't Close. It Moved."
+date: 2026-06-18
+categories: ["workflow patterns for human-ai teams", "augmenting knowledge work"]
+tags: ["claude code", "taste", "verification", "domain expertise", "agentic coding", "generalists", "human-ai teams", "augmentation"]
+excerpt: "I asked Claude to grade me as a developer. The answer inverted the question — and pointed at the one skill agents can't hand you: knowing when the output is wrong."
+---
+
+{==1,300-ish days into this AI/LLM moment, I wanted to pause, gaze at my navel, and assess what I've figured out so far using agents to build stuff. Naturally, I asked Geppetto Claude to grade me and pass judgement ;)==}{>>this is too personal. I'm keeping it in, but I think I should remove it.<<}{id="c3" by="user" at="2026-06-22T22:10:45.213Z"}
+
+> {==[This is a follow-up of sorts to a hypothetical conversation I had with Bertram Gilfoyle last year about what makes a 'developer'](https://humaine.studio/posts/2025/08/18/gilfoyle/)==}{>>this is too personal. I'm keeping it in, but I think I should remove it.<<}{id="c3" by="user" at="2026-06-22T22:10:45.213Z"}
+
+{==Maybe I could _actually_ code now and that the English degree and the self-taught nights has made me a [real boy, i mean developer](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnMydTgybmVhMzB3YjRrYWNiOGlyZnJjaWs4NjV5eDJvZDQ2ZG1qdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5BkTsCPkXcMNE5vBfI/giphy.gif) or just a convincing fascimile of one.==}{>>this is too personal. I'm keeping it in, but I think I should remove it.<<}{id="c3" by="user" at="2026-06-22T22:10:45.213Z"}
+
+Expertise is a tricky subject nowadays and its definition is slippery.
+
+An expert is "a person who has comprehensive and authoritative knowledge of or skill in a particular area" (NOAD)
+
+Deep skill, like coding proficiency, does not have the same predictive powers of expertise as they once did. Technical skills do little to determine how well someone is able to develop, use, and manage agents.
+
+Recent research suggests that domain knowledge, which may not be readily captured by training data, is a better predictor on using agents capablly.
+
+An accountant who knows the daily rhythms of reconciliation rules for their industry but has never written Python will run circles around a senior engineer touching a new language for the first time. The senior engineer, in that moment, is the novice.
+## What the research actually found
+Two recent studies from Anthropic.
+
+The first ([what makes Claude Code users effective](https://www.anthropic.com/research/claude-code-expertise)) looked at what separates experts from novices using the tool. Domain expertise won, not coding background. People decide _what_ to build — they own roughly seventy percent of those calls — and the agent decides _how_, owning about eighty percent of the execution. Experts trigger more than twice the agent actions per prompt than novices do. They drive harder because they know where they're going.
+
+The second study ([how AI assistance affects coding skill](https://www.anthropic.com/research/AI-assistance-coding-skills)) carried a warning. Developers who leaned on AI scored about seventeen percent lower on later assessments — close to two letter grades — than those who worked unaided. The largest drop showed up in debugging: knowing when code is wrong and why it fails. The skill most at risk of atrophy is the exact skill you need to supervise the machine.
+
+People who asked the agent to explain its reasoning, who posed conceptual questions, who debugged the errors themselves instead of pasting them back for a fix — they held their skill or gained it. The researchers put it plainly: **cognitive effort, even getting painfully stuck, builds mastery**. The tool can teach you or rot you, and your habits pick which.
+
+{==[Outsourcing cognition](https://pmc.ncbi.nlm.nih.gov/articles/PMC12714973/)==}{>>need to read this and talk about it more. Sometimes mowing your own lawn is better than hiring someone.<<}{id="c1" by="user" at="2026-06-18T15:46:15.287Z"}
+
+This is where the deep generalist wins. Curiosity gets you to a domain. Then you go deep, until you've earned the taste — the trained sense for what good looks like in compliance, or radio, or diabetes hardware. The checks come last, and they prove the taste is real instead of imagined. Do all three and you build things a narrow specialist and a pure generalist both miss: the specialist won't range wide enough, the generalist won't go deep enough to know when the output lies.
+## The gap Ira Glass named
+{==Ira Glass has a notable quote, from a 2007 [Gothamist](https://gothamist.com/arts-entertainment/ira-glass-this-american-life) interview, about taste. It came to mind when I was thinking about this missive as well as the twitter cognosetti blabbing about how important taste is to differentiated products.==}{>>this is terribly overwritten, but the big words were what were in my head.<<}{id="c2" by="user" at="2026-06-18T16:07:59.983Z"}
+
+> "Nobody tells this to people who are beginners, I wish someone told me. All of us who do creative work, we get into it because we have good taste. But there is this gap. For the first couple years you make stuff, it's just not that good... But your taste, the thing that got you into the game, is still killer. And your taste is why your work disappoints you."
+
+Ira's prescription was volume. Do a huge amount of work, finish one thing a week, and the gap between your taste and your output will close. Yeah. it's the boring shit. You put in the work and you gradually improve.
+
+The advice still holds. Us humans used to be a bottleneck to production. Agents can ship faster than we can read what happened, but this also
+
+You had taste on day one — you could hear a bad sentence, spot a clumsy interface, smell a wrong number. What you lacked was the thousands of reps to make your hands match your ear.
+
+Agents collapse that bottleneck. I describe a feature and Claude writes it across nine files, runs the tests, and commits. The reps I used to grind out by hand now arrive in seconds. So the production gap — the one Glass told us to close with volume — barely exists for me anymore.
+
+A different gap opened in its place. The gap between output that _looks_ right and output I've _proven_ right. That gap is now the whole job. Call it what it is: taste, relocated. Taste used to mean recognizing good work. Now it means catching the plausible-but-wrong thing that an agent hands you with total confidence.
+## How my work has adapted
+My workflow patterns are mostly building machinery to be skeptical of the machine and it's occassional stochastic outputs.
+
+When I had Claude plan and code some recent changes to a compliance product I'm working on, I send `/gilfoyle`, whose whole job is to tell me how/why Claude and I are wrong. It's a humorous and educational feedback loop.
+
+For more substantial work. I run several reviewers at once, each with a narrow brief: one hunts structural problems, one checks test coverage, one looks only for swallowed errors, one reads the comments against the actual code. On one recent change the four of them surfaced four distinct defects, and no single reviewer would have caught another's. One agent has blind spots. Four with different orders see more of the board.
+
+I use Steve Yegge's beads to keep a shared memory across sessions — a command-line log of decisions, so the agent and I avoid rehashing.
+
+The most consequential habit is also a dull one.
+
+I am consistently asking Claude to find ways to be things more simple, more verifiable, and "immutable" when they need to be. For those generalists out there, immutable just means that it can't be changed. It's a big deal for code wranglers.
+
+Agent self-reports are not evidence. But I've found that asking for the source truth behind claims helps a lot.
+
+It's my own paranoia about skillfulness transferred to my agent harness.
+## Hill Climbing
+I haven't arrive at those checks by reading a manual, because it doesn't exist. I earned each scar one by trusting blindly. The procedures are the protocols to prevent the next scar.
+
+A migration agent once told me it had moved everything — "all records migrated." I almost believed it. Then I dumped the raw rows and ran my own count: the source held 220, and the agent's own reports disagreed with themselves about whether the copy had 220 or 210. One off-hand "done" nearly cost me real data. The lesson became a rule: copy, don't move; keep the source until a reconciliation script I wrote — not the agent's word — proves the copy matches by content, row for row.
+
+I burned a string of sessions on a website that wouldn't update. I'd push code, see green, and assume the change was live. It wasn't. The hosting project took direct uploads, so a git push deployed nothing at all. The fix was humbling in its simplicity: a push is not a deploy. Now I `curl` the live URL and read the changed bytes back before I believe anything shipped.
+
+I have a clock that shows my blood sugar, built on an ESP32 microcontroller. Continuous integration — the automated build that runs on every change, CI for short — went green for weeks while the firmware failed on the actual chip. A fake build environment can't surface a bug that only the real silicon has. So I flash the device and watch it boot before I push, every time.
+
+Even my agents taught me this by failing. I once wired up an executor agent to escalate hard problems to a smarter advisor agent, and it couldn't — a dispatched subagent doesn't automatically get the tool to dispatch others. The escalation I'd assumed simply didn't exist until I designed it on purpose.
+
+Every one of those checks exists because I trusted output that looked right and got burned. The checks are self-referential at their core. I couldn't have written the verification rules in advance, because I didn't yet have the taste to know what deserved suspicion. The failures grew the taste. The taste became the checks.
+## For the generalist, and for the people studying us
+If you know a domain in your bones and you've talked yourself out of building because you're "not a real engineer" — stop apologizing. Your domain depth is the scarce input now. The agent supplies the syntax you were missing. Your job is to want the right thing, then to prove the machine actually delivered it. Both halves matter. Domain knowledge without checks ships confident nonsense. Checks without domain knowledge can't tell you what to check for.
+
+And to the researchers measuring how these skills form: the old rubric grades the wrong thing. Counting whether someone can write a sort from memory tells you less every month. The skills that compound are domain modeling, verification judgment, and the orchestration sense to direct several agents and catch their disagreements. Your own finding — that the same tool builds skill in active hands and erodes it in passive ones — means the variable worth measuring isn't _whether_ people use AI. It's _how_. Measure the habits, not the headcount.
+## Fight your way through
+Glass said you close the gap by doing a huge volume of work, and that you've just gotta fight your way through. The advice survives the agent era intact. The work hasn't vanished — it changed shape. The volume I put in now isn't typing. It's judgment: directing the work, then trying to prove it wrong, over and over, until catching the plausible-but-broken answer becomes reflex.
+
+That reflex is the new taste, and you grow it the way Glass said you grow the old one. You do a lot of it. You get painfully stuck on purpose. You fight your way through.

--- a/_drafts/when-automation-costs-more-than-manual-work.md
+++ b/_drafts/when-automation-costs-more-than-manual-work.md
@@ -1,0 +1,124 @@
+# Post-Mortem: When Automation Costs More Than Manual Work
+
+**Date:** 2025-12-12
+**Task:** Delete 24 inactive "Hide My Email" addresses on Apple's account page
+**Time spent:** ~1.5 hours
+**Manual time estimate:** ~5 minutes (24 emails × 3 clicks × 5 seconds)
+**Outcome:** Abandoned automation, did it manually
+
+## What Happened
+
+I wanted to clean up 24 inactive Hide My Email addresses on Apple's account management page. The web UI has a bug where it hangs on "Updating..." after each deletion (even though the backend succeeds). I thought: "Perfect use case for Playwright automation - handle the buggy UI, batch the deletions."
+
+I had Claude Code help me build it. We used the Jam.dev MCP to capture DOM selectors from a screen recording. The script successfully:
+- Logged in via 1Password CLI integration
+- Handled Apple's iframe-based auth
+- Waited for 2FA approval
+- Opened the inactive emails modal
+- Found 200+ email rows
+
+Then it fell apart. Multiple rounds of:
+1. Wrong selectors (active emails vs inactive)
+2. CSS syntax errors in Playwright locators
+3. Mismatched URLs (account.apple.com vs icloud.com)
+4. Rewrites that broke working code
+
+## The Core Mistakes
+
+### 1. No Upfront ROI Calculation
+Before writing any code, I should have asked: "Is this worth automating?"
+
+```
+Manual: 24 items × 3 clicks × 5 sec = 6 minutes
+Automation: Unknown, but "simple Playwright script" = 30 min estimate
+Break-even: Never (one-time task)
+```
+
+The only valid reasons to automate this:
+- It's a recurring task (it's not)
+- The count is 100+ items (it was 24)
+- Learning Playwright patterns (fair, but expensive lesson)
+
+### 2. Chasing the Wrong Abstraction
+When the Jam recording showed `icloud.com` instead of `account.apple.com`, I rewrote the entire login flow instead of asking: "Wait, which URL actually works?"
+
+The working code got replaced with broken code because I optimized for the wrong information.
+
+### 3. No Incremental Testing
+Each code change should have been tested before the next. Instead:
+- Changed selectors → didn't test
+- Changed URL → didn't test
+- Changed delete logic → didn't test
+- Ran script → multiple failures stacked
+
+### 4. Debugging Tools Added Too Late
+Playwright has excellent debugging:
+- `context.tracing.start()` captures DOM snapshots
+- `page.screenshot()` at each step
+- `npx playwright show-trace trace.zip` for replay
+
+I added tracing after 1+ hour of blind debugging. Should have been there from the start.
+
+### 5. Token/Context Burn
+Each failed run triggered:
+- Screenshot reads
+- Jam MCP calls for new recordings
+- Multiple file edits
+- Long explanations
+
+A tighter feedback loop (user runs script in terminal, reports error, I fix) would have saved significant context.
+
+## What I Should Have Done
+
+### Option A: Just Do It Manually (Best)
+Open the page, click through 24 emails. Done in 5 minutes. Move on with life.
+
+### Option B: Smarter Automation Approach
+If automation was truly warranted:
+
+1. **Start with tracing enabled** - debug tools from line 1
+2. **Test each step in isolation** - login script, then find-rows script, then delete script
+3. **Use Playwright Codegen** - `npx playwright codegen account.apple.com` records your clicks as code
+4. **Set a time box** - "If this isn't working in 20 minutes, I'll do it manually"
+
+### Option C: Different Tool Entirely
+For repetitive clicking tasks, simpler tools exist:
+- **Keyboard Maestro** (macOS) - record and replay clicks
+- **Browser macros** - iMacros, Selenium IDE
+- **AppleScript** + System Events - native macOS automation
+
+These don't require understanding DOM structure or Playwright's selector syntax.
+
+## Lessons for AI-Assisted Coding
+
+### When to Use AI for Automation
+- ✅ Complex, repeating workflows
+- ✅ Tasks requiring data transformation
+- ✅ Integration between multiple systems
+- ❌ One-time manual tasks under 15 minutes
+- ❌ Unstable/dynamic UIs without API access
+- ❌ When you'd need multiple auth flows
+
+### Red Flags to Abandon Ship
+- Third selector rewrite
+- "Let me try a different approach" more than twice
+- Debugging taking longer than estimated task time
+- Context window filling with failed attempts
+
+### Better AI Collaboration Patterns
+1. **Ask for effort estimate first** - "How long will this take vs. manual?"
+2. **Request debugging tools upfront** - "Add tracing and screenshots from the start"
+3. **Run tests yourself** - Don't burn tokens on "checking output"
+4. **Set explicit time boxes** - "We have 20 minutes, then we bail"
+
+## The Meta-Lesson
+
+Automation has a seductive appeal: "I'll save time forever!" But most tasks aren't forever. They're once.
+
+The sunk cost fallacy kicked in hard here. After 30 minutes, abandoning felt like "wasting" the work. But continuing wasted more.
+
+**The best automation is often no automation.**
+
+---
+
+*Written after manually deleting 24 emails in 4 minutes.*


### PR DESCRIPTION
Adds `_drafts/deirdre.md` — announcement post for [miqcie/deirdre](https://github.com/miqcie/deirdre), the McCloskey writing-reviewer agent. Sits in `_drafts/` so merging publishes nothing; move to `_posts/` with a date prefix when ready to ship.

## Insights
- The post reuses deirdre's real self-review output as material — the agent reviewing its own repo is the hook.
- Linted with the repo's own `llm-lint.sh`; only hard failures are quoted tic specimens (deliberate exhibits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New draft-only content with no runtime, config, or publish path until files leave `_drafts/`.
> 
> **Overview**
> Adds four unpublished markdown files under `_drafts/`, so nothing ships until they are moved into `_posts/` with a date prefix.
> 
> **`_drafts/deirdre.md`** is a Jekyll-ready announcement for the public [miqcie/deirdre](https://github.com/miqcie/deirdre) Claude Code writing reviewer: McCloskey-style prose review with mandatory rewrites, companion `llm-lint.sh` for CI, install steps, and the hook of the agent reviewing its own README.
> 
> The same PR also adds three other working drafts: **`constitution-gaps.md`** (long-form critique of Claude’s constitution from org-behavior / power / humanities angles), **`the-deep-generalists-taste-gap.md`** (essay on verification and “taste” with agent workflows, still carrying inline editorial comments), and **`when-automation-costs-more-than-manual-work.md`** (Playwright / Apple Hide My Email automation post-mortem).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41edfaffad0d47d703f373ed2f9556ca5bc1570f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->